### PR TITLE
Remove redundant information

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,16 +1,1 @@
-Closed License
-
-Copyright (c) 2019 Chatter, Coles Creation & Innovation & MicMacro. All rights reserved.
-
-This softwear is NOT avalable for copy/reuse. If you would like access to this softwear, contact us.
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Copyright (c) 2019 Chatter, Cole's Creation & Innovation & Michael M. All rights reserved.


### PR DESCRIPTION
This removes everything but the nonfree copyright. The author MicMacro is also changed to the actual author, Michael M. 